### PR TITLE
domain/backup - fix scan issues when duplicates images and no metadat…

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -44,6 +44,7 @@ func Backup(owner string, volume SourceVolume, optionsSlice ...Options) (Complet
 		ConcurrentCataloguer: ConcurrentCataloguer,
 		ConcurrentUploader:   ConcurrentUploader,
 		BatchSize:            BatchSize,
+		SkipRejects:          options.SkipRejects,
 	}
 
 	progressChannel, _ := run.start(context.TODO(), hintSize)

--- a/pkg/backup/scan.go
+++ b/pkg/backup/scan.go
@@ -39,6 +39,7 @@ func Scan(owner string, volume SourceVolume, optionSlice ...Options) ([]*Scanned
 		ConcurrentCataloguer: ConcurrentCataloguer,
 		ConcurrentUploader:   1,
 		BatchSize:            BatchSize,
+		SkipRejects:          options.SkipRejects,
 	}
 
 	progressChannel, _ := run.start(context.TODO(), hintSize)

--- a/pkg/backupadapters/analysers/exif/exif.go
+++ b/pkg/backupadapters/analysers/exif/exif.go
@@ -25,7 +25,7 @@ func (p *Parser) Supports(media backup.FoundMedia, mediaType backup.MediaType) b
 	return mediaType == backup.MediaTypeImage
 }
 
-func (p *Parser) ReadDetails(reader io.Reader, options backup.DetailsReaderOptions) (*backup.MediaDetails, error) {
+func (p *Parser) ReadDetails(reader io.Reader, _ backup.DetailsReaderOptions) (*backup.MediaDetails, error) {
 	buffer := bytes.NewBuffer(nil)
 	teeReader := io.TeeReader(reader, buffer)
 

--- a/pkg/catalogadapters/catalogdynamo/repository_media_crud_test.go
+++ b/pkg/catalogadapters/catalogdynamo/repository_media_crud_test.go
@@ -325,6 +325,12 @@ func (a *MediaCrudTestSuite) TestFindExistingSignatures() {
 	if a.NoError(err) {
 		a.Equal(exiting, signatures, "it should filter out any non exiting signature to keep the only 2 that exist")
 	}
+
+	search[1] = exiting[1]
+	signatures, err = a.repo.FindExistingSignatures(a.owner, search)
+	if a.NoError(err, "it should ignore duplicated keys") {
+		a.Equal(exiting, signatures, "it should ignore duplicated keys")
+	}
 }
 
 func (a *MediaCrudTestSuite) TestFindMediaCurrentAlbum() {


### PR DESCRIPTION
…a found

* scan were failing when an image was duplicated in the scanned folder (and was less than 100 media away)
* option "-s|--skip-errors" had no effect on scan or backups